### PR TITLE
default sample size increase + timing of request adjustment

### DIFF
--- a/predictionnet/__init__.py
+++ b/predictionnet/__init__.py
@@ -19,7 +19,7 @@
 
 # TODO(developer): Change this value when updating your code base.
 # Define the version of the template module.
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/predictionnet/utils/config.py
+++ b/predictionnet/utils/config.py
@@ -114,7 +114,7 @@ def add_args(cls, parser):
             "--neuron.sample_size",
             type=int,
             help="The number of miners to query in a single step.",
-            default=10,
+            default=15,
         )
 
         parser.add_argument(

--- a/predictionnet/validator/reward.py
+++ b/predictionnet/validator/reward.py
@@ -88,7 +88,7 @@ def get_rewards(
     # Round up current timestamp and then wait until that time has been hit
     rounded_up_time = timestamp - timedelta(minutes=timestamp.minute % 5,
                                     seconds=timestamp.second,
-                                    microseconds=timestamp.microsecond) + timedelta(minutes=5)
+                                    microseconds=timestamp.microsecond) + timedelta(minutes=5, seconds=30)
     
     ny_timezone = timezone('America/New_York')
 


### PR DESCRIPTION
This update will by default have validators sampling 15 miners instead of 10 now that the subnet has grown, and also hopefully fixes a validator error that occurs when requests are made too quickly